### PR TITLE
move 'change contact type' feature to 'otherActions' and add an icon

### DIFF
--- a/contacteditor.php
+++ b/contacteditor.php
@@ -143,14 +143,15 @@ function contacteditor_civicrm_permission(&$permissions) {
 
 function contacteditor_civicrm_summaryActions(&$actions, $contactID) {
   if (CRM_Core_Permission::check('Change CiviCRM contact type')) {
-    $actions['change_type'] = [
+    $actions['otherActions']['change contact type'] = array(
       'title' => 'Change Contact Type',
-      'weight' => 901,
+      'weight' => 999,
       'class' => 'no-popup',
       'ref' => 'change-contact-type',
       'key' => 'change-contact-type',
       'href' => CRM_Utils_System::url('civicrm/contacttypechange', ['contact_id' => $contactID]),
-    ];
+      'icon' => 'crm-i fa-exchange',
+    );
   }
 }
 

--- a/contacteditor.php
+++ b/contacteditor.php
@@ -143,15 +143,15 @@ function contacteditor_civicrm_permission(&$permissions) {
 
 function contacteditor_civicrm_summaryActions(&$actions, $contactID) {
   if (CRM_Core_Permission::check('Change CiviCRM contact type')) {
-    $actions['otherActions']['change contact type'] = array(
+    $actions['otherActions']['change_contact_type'] = [
       'title' => 'Change Contact Type',
-      'weight' => 999,
+      'weight' => 901,
       'class' => 'no-popup',
       'ref' => 'change-contact-type',
       'key' => 'change-contact-type',
       'href' => CRM_Utils_System::url('civicrm/contacttypechange', ['contact_id' => $contactID]),
       'icon' => 'crm-i fa-exchange',
-    );
+    ];
   }
 }
 


### PR DESCRIPTION
Previously, the 'Change Contact Type' option appeared in the **more** menu on the results page the search **Find Contacts**, however, the feature did not work from that menu and only rerouted the user to the record of the contact they tried to change. 

This PR moves the 'Change Contact Type' option into the 'otherActions' category (third column of the **Actions** menu), so that it only appears on the **Actions** menu from the contact's record (which is from where the user can actually change the contact type) and removes it from the **more** menu from the search view. 

Before (1)
![Selection_005](https://user-images.githubusercontent.com/87245718/175136092-f9e11b01-3774-4128-ad78-b64a364881e6.png)

This PR (2)
![Selection_001](https://user-images.githubusercontent.com/87245718/175136053-822ac244-b305-47ad-afa8-48cc8c510f66.png)

Before (1)
![Selection_004](https://user-images.githubusercontent.com/87245718/175136264-882d5bd1-996b-41e4-8e1c-8d9d0eceaa72.png)

This PR (2)
![Selection_002](https://user-images.githubusercontent.com/87245718/175136326-8c34e9c0-6ab5-40e7-8ed2-87c5e4a23f73.png)

To maintain visual consistency with the 'otherActions' options, this PR also adds an icon to the 'Change Contact Type' option.

Lastly, this PR changes the name of the `$actions` array element to `['change_contact_type']` instead of the previous `['change_type']`, to better match the name of the element with its functionality.
